### PR TITLE
feat: add intel tiger-lake gpu profile to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -319,6 +319,9 @@
         common-cpu-amd-zenpower = import ./common/cpu/amd/zenpower.nix;
         common-cpu-amd-raphael-igpu = import ./common/cpu/amd/raphael/igpu.nix;
         common-cpu-intel = import ./common/cpu/intel;
+        common-gpu-intel-tiger-lake =
+          deprecated "992" "common-gpu-intel-tiger-lake"
+            (import ./common/gpu/intel/tiger-lake);
         common-gpu-intel-comet-lake =
           deprecated "992" "common-gpu-intel-comet-lake"
             (import ./common/gpu/intel/comet-lake);


### PR DESCRIPTION
###### Description of changes
Exported the intel tiger-lake gpu profile from the flake.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the changes in your own NixOS Configuration
- [x] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

